### PR TITLE
Fix overlapping hero content on mobile

### DIFF
--- a/src/app/components/site/home/HomeHero.tsx
+++ b/src/app/components/site/home/HomeHero.tsx
@@ -78,6 +78,7 @@ export default function HomeHero() {
 
   return (
     <section
+      className="home-hero"
       style={{
         position: "relative",
         background: "#17110D",
@@ -154,6 +155,7 @@ export default function HomeHero() {
 
       {/* Content */}
       <div
+        className="home-hero-content"
         style={{
           position: "relative",
           zIndex: 2,
@@ -223,7 +225,7 @@ export default function HomeHero() {
       </div>
 
       {/* Thumbnail rail */}
-      <div style={{ position: "absolute", left: 0, right: 0, bottom: 0, zIndex: 3 }}>
+      <div className="home-hero-rail-wrap" style={{ position: "absolute", left: 0, right: 0, bottom: 0, zIndex: 3 }}>
         <div
           className="home-hero-rail"
           style={{

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -387,8 +387,21 @@
 .home-hero-h1 { font-size: clamp(34px, 6vw, 60px); }
 .home-hero-rail { grid-template-columns: repeat(4, 1fr); }
 @media (max-width: 720px) {
-    .home-hero-rail { grid-template-columns: repeat(2, 1fr); gap: 14px !important; }
-    .home-hero-rail .rail-desc { display: none; }
+    /* On mobile the vertically-centered text block and the absolutely
+       positioned thumbnail rail collide inside the fixed-height hero. Let the
+       hero grow to fit its content, top-align the text, and drop the rail into
+       normal flow beneath it so nothing overlaps. */
+    .home-hero { height: auto !important; min-height: 0 !important; }
+    .home-hero-content {
+        height: auto !important;
+        justify-content: flex-start !important;
+        padding-top: 48px !important;
+        padding-bottom: 36px !important;
+    }
+    .home-hero-rail-wrap { position: static !important; }
+    .home-hero-rail { grid-template-columns: repeat(2, 1fr); gap: 14px !important; padding-top: 4px; }
+    /* Inline display:block on the span outranks a bare class rule, so force it. */
+    .home-hero-rail .rail-desc { display: none !important; }
 }
 
 /* ─── Generic responsive grids for the marketing site ─── */


### PR DESCRIPTION
## Problem

On mobile, the home hero section renders broken: the **"Book a demo" / "Explore the platform"** CTA buttons overlap the industry tabs below them (**01 Equipment Manufacturers / 02 Specialty Chemicals / …**).

| Before | After |
| --- | --- |
| Buttons collide with the industry rail | Content flows cleanly, rail sits below |

### Root cause

`HomeHero` uses a **fixed-height** section (`min(820px, 92vh)`, min `640px`). Inside it:
- the text + CTA block is **vertically centered** (`justify-content: center`), and
- the industry thumbnail rail is **absolutely positioned** at the bottom (`position: absolute; bottom: 0`).

On desktop there's room to spare. On a narrow mobile viewport the tall four-line H1 + subhead + buttons block grows downward into the region the bottom rail occupies, so they overlap.

## Fix

Scoped entirely to mobile (`@media (max-width: 720px)`), desktop untouched:

- **`.home-hero`** → `height: auto` so the section grows to fit its content.
- **`.home-hero-content`** → top-aligned (`justify-content: flex-start`) with padding instead of vertical centering.
- **`.home-hero-rail-wrap`** → `position: static`, so the industry rail drops into normal document flow *beneath* the text rather than overlapping it.

Added three classes (`home-hero`, `home-hero-content`, `home-hero-rail-wrap`) in `HomeHero.tsx` to hook the media query.

### Secondary cleanup

The existing mobile rule `.home-hero-rail .rail-desc { display: none }` never actually worked — the span's inline `display: block` outranked the bare class selector, so the rail descriptions were shown on mobile despite the author's intent (the overlap just hid the symptom). Added `!important` so the mobile rail is compact as intended.

## Verification

- Production build (`next build`) passes.
- Verified with Playwright screenshots at 390px and 360px widths (no overlap, clean 2×2 rail) and 1280px (desktop layout unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_019gg61WRidnD9YDCEfokMS1)_