### PR TITLE
Inset edge rails on laptop-width screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,8 +126,12 @@
     color: var(--site-body);
     -webkit-font-smoothing: antialiased;
     position: relative;
-    /* Rail column is wider than the 1240 content so content never touches it. */
-    --rail-w: 1500px;
+    /* Rail column framing the 1240 content. Caps at 1500px on large monitors,
+       but pulls inward on laptop-width screens so the lines keep a visible
+       margin from the viewport edge instead of hugging it (e.g. a 14" MacBook
+       at ~1512px gets ~80px of inset rather than ~6px). The 1280px floor keeps
+       the lines just outside the 1240 content so they never cross into it. */
+    --rail-w: clamp(1280px, calc(100vw - 160px), 1500px);
 }
 
 /* Stripe-style vertical rails marking the edges of the content column, running


### PR DESCRIPTION
## Problem

The vertical framing rails (Stripe-style lines running down the edges of the content column) used a fixed `--rail-w: 1500px`. On a ~1512px viewport — e.g. a **14" MacBook** — a 1500px centered column leaves only **~6px** on each side, so the lines sit right against the screen edge and are barely visible.

## Fix

Made the rail column width responsive:

```css
--rail-w: clamp(1280px, calc(100vw - 160px), 1500px);
```

- **Large monitors (≥1660px):** capped at `1500px` — the original framing is preserved, unchanged.
- **Laptop widths (~1440–1660px, incl. the 14" MacBook at 1512px):** pulls inward to a **~80px** margin from each edge, so the lines are clearly visible with a comfortable gap to the content.
- **Floor at 1280px:** keeps the lines just outside the 1240px content column so they never cross into the cards, even at the narrow end.

Rails still only appear above the existing `1360px` breakpoint, so **mobile is unchanged** (lines stay hidden, as requested). The same variable drives the hero-overlay rails and the amber CTA-band rails, so all three move together consistently.

## Verification

Measured the rail inset (px from each screen edge) and screenshotted across widths with Playwright:

| Viewport | Inset from edge | Notes |
|---|---|---|
| 1366px | 43px | floor engaged, still clear of content |
| **1512px (14" MacBook)** | **80px** | was ~6px |
| 1440px | 80px | |
| 1680px | 90px | |
| 1920px | 210px | original 1500px framing preserved |
| 2560px | 530px | original framing preserved |
| 390px (mobile) | hidden | `display: none`, unchanged |

Confirmed the content rails, hero rails, and CTA-band rails all inset consistently, with a visible gap to the cards.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gg61WRidnD9YDCEfokMS1)_