### PR TITLE
Update Forward-Deployed Engineer role blurb

### DIFF
--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -14,7 +14,7 @@ const ROLES = [
   {
     title: "Forward-Deployed Engineer",
     meta: "Full time · On site with customers across North America",
-    body: "Embed with industrial customers, map how their work actually flows, and deploy the AI workforce on their floor. You own the outcome, not a ticket queue.",
+    body: "Own customer outcomes by embedding alongside their team, mapping their workflows, and deploying Aerium's AI workforce across their organization.",
     subject: "Application: Forward-Deployed Engineer",
   },
 ];


### PR DESCRIPTION
## What

Rewords the open-role description for **Forward-Deployed Engineer** on the careers page (`src/app/careers/page.tsx`).

**Before:**
> Embed with industrial customers, map how their work actually flows, and deploy the AI workforce on their floor. You own the outcome, not a ticket queue.

**After:**
> Own customer outcomes by embedding alongside their team, mapping their workflows, and deploying Aerium's AI workforce across their organization.

(Trailing period added to match the style of the other copy on the page.)

## Verification
- Rendered the `/careers` page locally and confirmed the new blurb displays correctly in the "Join the team" card.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gg61WRidnD9YDCEfokMS1)_